### PR TITLE
fix: Card 컴포넌트 라우트 삭제, Main페이지에 넣기

### DIFF
--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -11,7 +11,6 @@ export default function Router() {
       <Routes>
         <Route path="/" element={<Main />}>
           <Route path=":movieTitle" element={<Main />} />
-          <Route path="/detail/:movieId" element={<Card />} />
           <Route path="/favorites" element={<Main favorites={true} />} />
         </Route>
         <Route path="/login" element={<Login />} />

--- a/src/component/card.jsx
+++ b/src/component/card.jsx
@@ -1,15 +1,12 @@
 import React, { useEffect } from "react";
 import styled from "styled-components";
-import theme from "../theme";
 import { useMovieModel } from "../models/useMovieModel";
-import { useNavigate } from "react-router-dom";
 import CloseIcon from "../images/icons/close-icon.png";
 import PlusIcon from "../images/icons/plus-icon.png";
 
 const IMAGE_BASE_URL = "https://image.tmdb.org/t/p/original";
 
-export default function Card({ movieId }) {
-  const navigate = useNavigate();
+export default function Card({ movieId, setSelectedMovieId }) {
   const { movie, getMovieById } = useMovieModel();
 
   useEffect(() => {
@@ -20,7 +17,7 @@ export default function Card({ movieId }) {
     <Modal>
       <Image src={`${IMAGE_BASE_URL}${movie?.backdrop_path}`} alt="movie image" />
       <MovieInfo>
-        <PlusButton src={PlusIcon} />
+        <PlusButton src={PlusIcon} onClick={() => {}} />
         <H1>{movie?.original_title}</H1>
         <H2>{movie?.tagline}</H2>
         <Tag>{movie?.status === "Released" ? new Date(movie?.release_date).getFullYear() : "unreleased"}</Tag>
@@ -32,7 +29,7 @@ export default function Card({ movieId }) {
         <p>Production Countries : {movie?.production_countries.map((country) => country.name).join(", ")}</p>
         <p>Production Company : {movie?.production_companies.map((company) => company.name).join(", ")}</p>
       </MovieInfo>
-      <CloseButton src={CloseIcon} onClick={() => navigate("/")} />
+      <CloseButton src={CloseIcon} onClick={() => setSelectedMovieId(null)} />
     </Modal>
   );
 }

--- a/src/component/thumbnail.jsx
+++ b/src/component/thumbnail.jsx
@@ -1,14 +1,11 @@
-import React from 'react';
-import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
+import React from "react";
+import styled from "styled-components";
 
-export default function Thumbnail({ movie }) {
-  const IMAGE_BASE_URL = 'https://image.tmdb.org/t/p/original';
-
-  const navigate = useNavigate();
+export default function Thumbnail({ movie, setSelectedMovieId }) {
+  const IMAGE_BASE_URL = "https://image.tmdb.org/t/p/original";
 
   const handleThumbnailClick = (movieId) => {
-    navigate(`/detail/${movieId}`);
+    setSelectedMovieId(movieId);
   };
 
   return (

--- a/src/models/useMovieModel.js
+++ b/src/models/useMovieModel.js
@@ -17,7 +17,7 @@ export const useMovieModel = () => {
   };
 
   const getMovieById = async (id) => {
-    movieDataService.get(`/movie/${id}`, {}, getMovieByIdCallback);
+    movieDataService.get(`/movie/${id}`, getMovieByIdCallback);
   };
 
   const searchMovies = (keyword = null) => {

--- a/src/pages/main.jsx
+++ b/src/pages/main.jsx
@@ -1,17 +1,17 @@
-import React, { useEffect } from 'react';
-import styled from 'styled-components';
-import { useParams } from 'react-router-dom';
-
-import { useMovieModel } from '../models/useMovieModel';
-
-import Thumbnail from '../component/Thumbnail';
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+import { useParams } from "react-router-dom";
+import { removeToken, getLoggedInUser } from "../utils/library";
+import { useMovieModel } from "../models/useMovieModel";
+import Thumbnail from "../component/thumbnail";
+import Card from "../component/card";
 
 export default function Main() {
   const { movies, searchMovies } = useMovieModel();
-
+  const [selectedMovieId, setSelectedMovieId] = useState(null);
   const { movieTitle } = useParams();
   // 이성진
- const [loggedInUser, setLoggedInUser] = useState(false);
+  const [loggedInUser, setLoggedInUser] = useState(false);
 
   const logout = () => {
     removeToken();
@@ -30,11 +30,14 @@ export default function Main() {
   }
 
   return (
-    <ThumbnailList>
-      {movies?.results.map((movie) => (
-        <Thumbnail key={movie.id} movie={movie} />
-      ))}
-    </ThumbnailList>
+    <>
+      <ThumbnailList>
+        {movies?.results.map((movie) => (
+          <Thumbnail key={movie.id} movie={movie} setSelectedMovieId={setSelectedMovieId} />
+        ))}
+      </ThumbnailList>
+      {selectedMovieId && <Card movieId={selectedMovieId} setSelectedMovieId={setSelectedMovieId}/>}
+    </>
   );
 }
 


### PR DESCRIPTION
Card컴포넌트를 라우터에서 삭제.
Card를 Main페이지에 넣고 selectedMovieId가 있을때만 렌더링되도록 했습니다.

thumbnail이랑 main페이지도 조금 수정했습니다.
(thumbnail 클릭했을때 navigate되지 않고 setSelectedMovieId(movieId)실행되도록)

useMovieModel.js 에서는 운기님이 파라미터를 하나 더 전달해서, 제가 하나 지웠습니다. 
그래야 동작합니다..